### PR TITLE
Fix references being detached on rebalance

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function set(equals, map, key, keyOffset, value) {
 		return false
 	} else {
 		const n = (map[k] = new Array(256))
-		set(equals, n, r.key, keyOffset + 1, r.value)
+		setReference(equals, n, r.key, keyOffset + 1, r)
 		set(equals, n, key, keyOffset + 1, value)
 		return true
 	}
@@ -63,8 +63,27 @@ function getReference(equals, map, key, keyOffset, insert) {
 	} else {
 		if (insert) {
 			const n = (map[k] = new Array(256))
-			set(equals, n, r.key, keyOffset + 1, r.value)
+			setReference(equals, n, r.key, keyOffset + 1, r)
 			return getReference(equals, n, key, keyOffset + 1, true)
 		}
+	}
+}
+
+function setReference(equals, map, key, keyOffset, reference) {
+	const k = key[keyOffset]
+	const r = map[k]
+	if (Array.isArray(r)) {
+		return setReference(equals, r, key, keyOffset + 1, reference)
+	} else if (r === undefined) {
+		map[k] = reference
+		return true
+	} else if (equals(r.key, key)) {
+		map[k] = reference
+		return false
+	} else {
+		const n = (map[k] = new Array(256))
+		setReference(equals, n, r.key, keyOffset + 1, r)
+		setReference(equals, n, key, keyOffset + 1, reference)
+		return true
 	}
 }

--- a/test.js
+++ b/test.js
@@ -125,6 +125,22 @@ test('Get reference with insertion', (t) => {
 	t.end()
 })
 
+test('A reference follows the key', (t) => {
+	const keyA = new Uint8Array([4, 2, 2])
+	const keyB = new Uint8Array([4, 2, 3])
+	const map = create(equals)
+	const r = map.getReference(keyA, 1)
+
+	map.set(keyB, 2)
+
+	t.ok(map.getReference(keyA) === r, 'the reference survives rebalancing')
+
+	map.set(keyA, 3)
+
+	t.ok(map.getReference(keyA) === r, 'the reference survives updates')
+	t.end()
+})
+
 test('Alternative equals function', (t) => {
 	const keyA = new Uint8Array([4, 2])
 	const keyB = new Uint8Array([4, 3])


### PR DESCRIPTION
When a new key is inserted with a prefix matching an existing key, a new level in the tree structure is introduced and the existing as well as the new key is inserted into it (rebalancing). The result was the old node being discarded and a new one being created, rendering any previous result from `getReference` for the particular key useless for in-place updates.

This change moves any existing node rather than recreating it at the new nested level.

In theory it should also be slightly faster at rebalancing as one less object is created.